### PR TITLE
fix: CTW3 device_status parsing, BLE stability, and mode-change fix

### DIFF
--- a/PetkitW5BLEMQTT/ble_manager.py
+++ b/PetkitW5BLEMQTT/ble_manager.py
@@ -20,7 +20,7 @@ class BLEManager:
     async def scan(self):
         self.logger.info("Scanning for Petkit BLE devices...")
         devices = await BleakScanner.discover()
-        self.available_devices = {dev.address: dev for dev in devices if any(supported_device in dev.name for supported_device in Constants.SUPPORTED_DEVICES)}
+        self.available_devices = {dev.address: dev for dev in devices if dev.name and any(supported_device in dev.name for supported_device in Constants.SUPPORTED_DEVICES)}
         for address, device in self.available_devices.items():
             self.logger.info(f"Found device: {device.name} ({address})")
             self.connectiondata[address] = device

--- a/PetkitW5BLEMQTT/constants.py
+++ b/PetkitW5BLEMQTT/constants.py
@@ -4,16 +4,14 @@ class Constants:
 
     CTW2_NAME = "Petkit_CTW2"
     CTW3_NAME = "Petkit_CTW3"
+    CTW3_2_NAME = "Petkit_CTW3_2"
+    CTW3_100_NAME = "Petkit_CTW3_100"
+    CTW3_UV_NAME = "Petkit_CTW3UV"
+    CTW3_UV_100_NAME = "Petkit_CTW3UV_100"
     W5C_NAME = "Petkit_W5C"
     W5N_NAME = "Petkit_W5N"
     W5_NAME = "Petkit_W5"
     W4X_NAME = "Petkit_W4X"
     W4X_UVC_NAME = "Petkit_W4XUVC"
-    CTW3_100_NAME = "Petkit_CTW3_100";
-    CTW3_2_NAME = "Petkit_CTW3_2";
-    CTW3_NAME = "Petkit_CTW3";
-    CTW3_UV_100_NAME = "Petkit_CTW3UV_100";
-    CTW3_UV_NAME = "Petkit_CTW3UV";
-
 
     SUPPORTED_DEVICES = ["W4", "W5", "CTW2", "CTW3"]

--- a/PetkitW5BLEMQTT/mqtt_callback.py
+++ b/PetkitW5BLEMQTT/mqtt_callback.py
@@ -81,7 +81,7 @@ class MQTTCallback:
             
         if key == "mode":
             self.logger.info(f"Setting mode to {value}.")
-            await self.commands.set_device_mode(self.device.status["running_status"], value)
+            await self.commands.set_device_mode(self.device.status["power_status"], value)
             
         if key == "reset_filter":
             self.logger.info(f"Resetting filter.")

--- a/PetkitW5BLEMQTT/parsers.py
+++ b/PetkitW5BLEMQTT/parsers.py
@@ -149,6 +149,57 @@ class Parsers:
     # Status
     @staticmethod
     def device_status(data, alias):
+        if alias == "CTW3":
+            # CTW3 has 10 extra state bytes compared to generic devices.
+            # State section is 26 bytes (data[0:26]), config section starts at data[26].
+            mode = data[2]
+            filter_percentage = data[13] / 100.0
+            pump_runtime = Utils.bytes_to_integer(data[9:13])
+            pump_runtime_today = Utils.bytes_to_integer(data[15:19])
+
+            # Config fields follow state section at offset 26 (present in CMD 230 full status)
+            smart_time_on = data[26] if len(data) > 26 else 0
+            smart_time_off = data[27] if len(data) > 27 else 0
+            led_switch = data[28] if len(data) > 28 else None
+            led_brightness = data[29] if len(data) > 29 else None
+            dnd_switch = data[34] if len(data) > 34 else None
+
+            filter_time_left, purified_water, purified_water_today, energy_consumed = Utils.calculate_values(
+                mode, filter_percentage, smart_time_on, smart_time_off, alias, pump_runtime_today, pump_runtime
+            )
+
+            return {
+                "power_status": data[0],
+                "suspend_status": data[1],
+                "mode": mode,
+                "electric_status": data[3],
+                "dnd_state": data[4],
+                "warning_breakdown": data[5],
+                "warning_water_missing": data[6],
+                "low_battery": data[7],
+                "warning_filter": data[8],
+                "pump_runtime": pump_runtime,
+                "filter_percentage": filter_percentage,
+                "running_status": data[14],
+                "pump_runtime_today": pump_runtime_today,
+                "pet_drinking": data[19],
+                "supply_voltage": Utils.bytes_to_short(data[20:22]),
+                "battery_voltage": Utils.bytes_to_short(data[22:24]),
+                "battery_percentage": data[24],
+                "module_status": data[25],
+                "smart_time_on": smart_time_on,
+                "smart_time_off": smart_time_off,
+                "led_switch": led_switch,
+                "led_brightness": led_brightness,
+                "do_not_disturb_switch": dnd_switch,
+                "pump_runtime_readable": Utils.get_timestamp_days(pump_runtime),
+                "pump_runtime_today_readable": Utils.get_timestamp_hours(pump_runtime_today),
+                "filter_time_left": filter_time_left,
+                "purified_water": purified_water,
+                "purified_water_today": purified_water_today,
+                "energy_consumed": energy_consumed,
+            }
+
         mode = data[1]
         filter_percentage = Utils.byte_to_integer(data[10]) / 100
         smart_time_on = data[16]

--- a/PetkitW5BLEMQTT/parsers.py
+++ b/PetkitW5BLEMQTT/parsers.py
@@ -182,7 +182,7 @@ class Parsers:
                 "filter_percentage": filter_percentage,
                 "running_status": data[14],
                 "pump_runtime_today": pump_runtime_today,
-                "pet_drinking": data[19],
+                "detect_status": data[19],
                 "supply_voltage": Utils.bytes_to_short(data[20:22]),
                 "battery_voltage": Utils.bytes_to_short(data[22:24]),
                 "battery_percentage": data[24],

--- a/PetkitW5BLEMQTT/utils.py
+++ b/PetkitW5BLEMQTT/utils.py
@@ -281,6 +281,9 @@ class Utils:
     # device.filter_percentage, device.smart_time_on, device.smart_time_off
     @staticmethod
     def calculate_remaining_filter_time(filter_percentage, time_on, time_off):
+        if time_on == 0:
+            # Fallback when smart mode times are unavailable (e.g. CTW3 short packet)
+            return math.ceil(filter_percentage * 60)
         return math.ceil(((filter_percentage * 30.0) * (time_on + time_off)) / time_on)
     
     @staticmethod


### PR DESCRIPTION
## Summary

This PR fixes several bugs affecting CTW3/CTW3UV/CTW3_100 family devices. Fixes issues #5 and #6.

### parsers.py — CTW3 branch in \device_status()\ (CMD 230)
The CTW3 device_status frame has 10 extra state bytes compared to generic W4/W5 devices. The generic parser was reading wrong byte offsets, causing incorrect readings (e.g. \ilter_percentage\ showing 2% instead of the real 93%).

Correct CTW3 offsets (vs generic):
| Field | CTW3 | Generic |
|-------|------|---------|
| \mode\ | \data[2]\ | \data[1]\ |
| \pump_runtime\ | \data[9:13]\ | \data[6:10]\ |
| \ilter_percentage\ | \data[13] / 100.0\ | \data[10] / 100\ |
| \unning_status\ | \data[14]\ | \data[11]\ |
| \pump_runtime_today\ | \data[15:19]\ | \data[12:16]\ |
| \smart_time_on/off\ | \data[26]/data[27]\ | \data[16]/data[17]\ |

Also exposes CTW3-specific fields: \pet_drinking\, \supply_voltage\, \attery_voltage\, \attery_percentage\.

### utils.py — Division-by-zero guard for Smart Mode
\calculate_remaining_filter_time()\ divided by \smart_time_on\. When \	ime_on = 0\ (CTW3 status packets do not always carry smart-time fields), this raised a \ZeroDivisionError\. Added a guard that falls back to \ceil(filter_percentage * 60)\ days.

### ble_manager.py — None check for device name during scan
During BLE scanning, \dev.name\ can be \None\ for devices that don't advertise a name. The string comparison \supported_device in dev.name\ caused a \TypeError\. Added an explicit \dev.name and\ guard.

### mqtt_callback.py — Use \power_status\ instead of \unning_status\ for mode changes
In Smart Mode the pump cycles on/off. During the off-phase, \unning_status = 0\. Sending \set_device_mode(running_status=0, mode=2)\ told the device to **stop** rather than change mode. Changed to use \power_status\ (always \1\ while the device is powered on) for mode-change commands.

### constants.py — Cleanup
- Removed duplicate \CTW3_NAME\ definition (was defined twice with same value)
- Removed stray semicolons from constant definitions
- Reordered constants for clarity